### PR TITLE
Logging with logfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# ignoring log.txt
+log.txt

--- a/README.md
+++ b/README.md
@@ -12,8 +12,4 @@ https://golang.org/
   ```GOARCH=arm64 GOOS=linux go build ./parallel/egoParallel.go```  
   Would build for arm64, linux (raspi etc, sometimes you may need just arm)  
   See entries in bold for supported OS and Architectures out of the box: https://gist.github.com/asukakenji/f15ba7e588ac42795f421b48b8aede63  
-  1. Make sure you FILTER the output:  
-  \*NIX ```| grep e```  
-  Powershell ```| Select-String e```  
-  CMD ```| find "e"```  
   1. New: try -hard as a flag, sets the iterations and precision higher to give your CPU a workout! Overrides any set precision or iterations!

--- a/parallel/egoParallel.go
+++ b/parallel/egoParallel.go
@@ -3,6 +3,8 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
+	"os"
 	"time"
 
 	"github.com/ericlagergren/decimal"
@@ -16,6 +18,16 @@ var (
 )
 
 func main() {
+	// Logger
+	f, err := os.OpenFile("log.txt",
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Println(err)
+	}
+	defer f.Close()
+	logger := log.New(f, "eGoDecimal", log.LstdFlags)
+
+	// Iterations
 	precPtr := flag.Int("p", 10001, "Precision for calculations")
 	iterPtr := flag.Uint64("i", 1625, "Value of infinity")
 	hard := flag.Bool("hard", false, "Stress your hardware more, more iterations! Forces set iterations and precison, overiding any set.")
@@ -38,10 +50,14 @@ func main() {
 		//fmt.Print(".")
 		//time.Sleep(time.Millisecond*5)
 	}
-	fmt.Println()
-	fmt.Println(answer)
-	fmt.Print("Time: ")
-	fmt.Println(time.Now().Sub(start))
+
+	// Logging
+	logger.Println(answer)
+	logger.Printf("\nRun Time: %v\n", time.Now().Sub(start))
+
+	// Print result to console
+	fmt.Printf("Run Time: %v\n", time.Now().Sub(start))
+
 }
 func series(lower, upper uint64) {
 	var res = decimal.WithPrecision(precision).SetUint64(0)

--- a/parallel/egoParallel.go
+++ b/parallel/egoParallel.go
@@ -18,6 +18,13 @@ var (
 )
 
 func main() {
+	// Options
+	precPtr := flag.Int("p", 10001, "Precision for calculations")
+	iterPtr := flag.Uint64("i", 1625, "Value of infinity")
+	hard := flag.Bool("hard", false, "Stress your hardware more, more iterations! Forces set iterations and precison, overiding any set.")
+	debug := flag.Bool("debug", false, "Used for debugging. This will write to log.txt")
+	flag.Parse()
+
 	// Logger
 	f, err := os.OpenFile("log.txt",
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
@@ -25,13 +32,9 @@ func main() {
 		log.Println(err)
 	}
 	defer f.Close()
-	logger := log.New(f, "eGoDecimal", log.LstdFlags)
+	logger := log.New(f, "eGoDecimal ", log.LstdFlags)
 
 	// Iterations
-	precPtr := flag.Int("p", 10001, "Precision for calculations")
-	iterPtr := flag.Uint64("i", 1625, "Value of infinity")
-	hard := flag.Bool("hard", false, "Stress your hardware more, more iterations! Forces set iterations and precison, overiding any set.")
-	flag.Parse()
 	precision = *precPtr
 	iterations = *iterPtr
 	if *hard {
@@ -40,7 +43,7 @@ func main() {
 	}
 	start := time.Now()
 	channel = make(chan *decimal.Big, iterations)
-	//go series(0,*iterPtr)
+	//go series(0, *iterPtr)
 	var answer = decimal.WithPrecision(precision).SetUint64(0)
 	for i := uint64(1); i < iterations; i++ {
 		go series(i-1, i)
@@ -52,10 +55,13 @@ func main() {
 	}
 
 	// Logging
-	logger.Println(answer)
-	logger.Printf("\nRun Time: %v\n", time.Now().Sub(start))
+	if *debug {
+		logger.Println(answer)
+		logger.Printf("\nRun Time: %v\n", time.Now().Sub(start))
+	}
 
-	// Print result to console
+	// Print result to console and write to log
+	logger.Printf("\nRun Time: %v\n", time.Now().Sub(start))
 	fmt.Printf("Run Time: %v\n", time.Now().Sub(start))
 
 }


### PR DESCRIPTION
Added logging and a `-debug` option.

Future writes to the logfile can be made via `logger.printf()` or `logger.println()` 